### PR TITLE
Improve resource cleanup and updater robustness

### DIFF
--- a/app/src/main/java/com/buligin/vishnucast/SignalingSocket.kt
+++ b/app/src/main/java/com/buligin/vishnucast/SignalingSocket.kt
@@ -31,17 +31,7 @@ object WebRtcCoreHolder {
     fun closeAndClear() = synchronized(this) {
         val inst = instance
         if (inst != null) {
-            // Без прямой ссылки на WebRtcCore.close() — чтобы не ловить Unresolved reference
-            try {
-                // Порядок важен: сперва пытаемся вызвать close(), если это наш WebRtcCore
-                inst.javaClass.getMethod("close").invoke(inst)
-            } catch (_: Throwable) { /* no-op */
-            }
-            try {
-                // Если WebRTC-сущности (PeerConnectionFactory/Source/Track) есть → dispose
-                inst.javaClass.getMethod("dispose").invoke(inst)
-            } catch (_: Throwable) { /* no-op */
-            }
+            try { inst.close() } catch (_: Throwable) {}
         }
         instance = null
     }

--- a/app/src/main/java/com/buligin/vishnucast/UpdateChecker.kt
+++ b/app/src/main/java/com/buligin/vishnucast/UpdateChecker.kt
@@ -65,13 +65,23 @@ object UpdateChecker {
             setRequestProperty("Accept", "application/json")
             setRequestProperty("User-Agent", "VishnuCast/${BuildConfig.VERSION_NAME} (Android ${Build.VERSION.RELEASE})")
         }
-        conn.inputStream.use { ins ->
-            BufferedReader(InputStreamReader(ins)).use { br ->
-                val sb = StringBuilder()
-                var line: String?
-                while (br.readLine().also { line = it } != null) sb.append(line).append('\n')
-                return sb.toString()
+        return try {
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            val body = stream?.use { ins ->
+                BufferedReader(InputStreamReader(ins)).use { br ->
+                    val sb = StringBuilder()
+                    var line: String?
+                    while (br.readLine().also { line = it } != null) sb.append(line).append('\n')
+                    sb.toString()
+                }
+            } ?: ""
+            if (code !in 200..299) {
+                throw IllegalStateException("HTTP $code: ${body.take(200)}")
             }
+            body
+        } finally {
+            conn.disconnect()
         }
     }
 

--- a/app/src/main/java/com/buligin/vishnucast/UpdateManager.kt
+++ b/app/src/main/java/com/buligin/vishnucast/UpdateManager.kt
@@ -43,6 +43,8 @@ object UpdateManager {
 
     private var job: Job? = null
     private var downloadId: Long = -1L
+    private var downloadFile: File? = null
+    private var dmContext: Context? = null
 
     /**
      * Начать скачивание APK.
@@ -53,12 +55,15 @@ object UpdateManager {
         cancel() // на всякий
         _state.value = State.Idle
 
+        dmContext = ctx.applicationContext
+
         val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
 
         // Каталог внутри "Downloads" нашего приложения (стабильно для FileProvider)
         val destDir = ctx.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: ctx.filesDir
         destDir.mkdirs()
         val outFile = File(destDir, fileName)
+        downloadFile = outFile
         if (outFile.exists()) outFile.delete()
 
         val uri = Uri.parse(url)
@@ -124,8 +129,7 @@ object UpdateManager {
     }
 
     fun cancel() {
-        job?.cancel()
-        job = null
+        cleanupDownload(removeFromDm = true, deleteFile = true)
         _state.value = State.Idle
     }
 
@@ -338,7 +342,29 @@ object UpdateManager {
 
     private fun fail(msg: String): Boolean {
         Log.e(TAG, msg)
+        cleanupDownload(removeFromDm = true, deleteFile = true)
         _state.value = State.Failed(msg)
         return false
+    }
+
+    private fun cleanupDownload(removeFromDm: Boolean, deleteFile: Boolean) {
+        job?.cancel()
+        job = null
+
+        val ctx = dmContext
+        if (removeFromDm && downloadId >= 0 && ctx != null) {
+            runCatching {
+                val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+                dm.remove(downloadId)
+            }
+        }
+
+        if (deleteFile) {
+            runCatching { downloadFile?.takeIf { it.exists() }?.delete() }
+        }
+
+        downloadId = -1L
+        downloadFile = null
+        dmContext = null
     }
 }

--- a/app/src/main/java/com/buligin/vishnucast/WebRtcCore.kt
+++ b/app/src/main/java/com/buligin/vishnucast/WebRtcCore.kt
@@ -24,6 +24,7 @@ import kotlin.math.sqrt
 class WebRtcCore(private val ctx: Context) {
 
     private val pendingPeerCount = AtomicInteger(0)
+    private val closed = AtomicBoolean(false)
     private var guardTimer: Timer? = null
 
     // Аудио-только: без EglBase и без видео-фабрик
@@ -96,6 +97,24 @@ class WebRtcCore(private val ctx: Context) {
         d("init: ADM & audioTrack ready, start muted")
 
         startGuardTimer()
+    }
+
+    fun close() {
+        if (!closed.compareAndSet(false, true)) return
+
+        try { guardTimer?.cancel() } catch (_: Throwable) {}
+        guardTimer = null
+
+        try { statsTimer?.cancel() } catch (_: Throwable) {}
+        statsTimer = null
+        statsPc = null
+
+        probe.stop()
+
+        try { audioTrack.dispose() } catch (_: Throwable) {}
+        try { audioSource.dispose() } catch (_: Throwable) {}
+        try { factory.dispose() } catch (_: Throwable) {}
+        try { adm.release() } catch (_: Throwable) {}
     }
 
     private fun startGuardTimer() {


### PR DESCRIPTION
## Summary
- add explicit close logic to WebRtcCore and use it from the shared holder
- cancel download manager jobs and delete temporary files when updates are cancelled or fail
- validate HTTP responses in UpdateChecker and disconnect connections reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b1c04d108320a3d1300c0c4d5e13)