### PR TITLE
Handle captive portal requests for hotspot clients

### DIFF
--- a/app/src/main/java/com/buligin/vishnucast/VishnuServer.kt
+++ b/app/src/main/java/com/buligin/vishnucast/VishnuServer.kt
@@ -32,7 +32,15 @@ class VishnuServer(
             "/apple-touch-icon.png" -> asset("apple-touch-icon.png", "image/png")
             "/favicon.png" -> asset("favicon.png", "image/png")
 
-            else               -> newFixedLengthResponse(Status.NOT_FOUND, "text/plain", "Not found")
+            // Частые пути проверки подключений (Captive Portal). Отдаём страницу сразу,
+            // чтобы ОС открыла встроенный браузер/"требуется действие сети".
+            "/generate_204", "/gen_204", "/hotspot-detect.html", "/connecttest.txt", "/ncsi.txt" ->
+                asset("index.html", "text/html; charset=utf-8")
+
+            // Любые другие пути — мягкий редирект на корень, чтобы клиент всегда видел портал
+            else -> newFixedLengthResponse(Status.REDIRECT, "text/plain", "").apply {
+                addHeader("Location", "/")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- serve common captive-portal probe paths with the built-in player page
- redirect other HTTP paths to the root page so hotspot clients always land on the player

## Testing
- bash gradlew test (fails: Gradle wrapper download blocked by proxy)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926fc12f02083209e53d751da0d2624)